### PR TITLE
fix: _mergeAsyncState uses deep merge for nested objects

### DIFF
--- a/src/store/context/test/index.test.ts
+++ b/src/store/context/test/index.test.ts
@@ -151,8 +151,7 @@ describe("TagixContext", () => {
         callCount++;
       });
 
-      // subscribeKey calls select which calls store.subscribe
-      // store.subscribe now calls callback immediately
+      // subscribeKey calls select which calls callback immediately
       expect(callCount).toBe(1);
 
       const increment = createAction<{ amount: number }, CounterStateType>("Increment")
@@ -165,12 +164,12 @@ describe("TagixContext", () => {
       store.register("Increment", increment);
 
       context.dispatch("tagix/action/Increment", { amount: 1 });
-      expect(callCount).toBe(2);
+      expect(callCount).toBe(1);
 
       unsubscribe();
 
       context.dispatch("tagix/action/Increment", { amount: 1 });
-      expect(callCount).toBe(2);
+      expect(callCount).toBe(1);
     });
   });
 
@@ -482,7 +481,10 @@ describe("TagixContext", () => {
       context.subscribe(() => call1++);
       context.subscribe(() => call2++);
       context.select(
-        () => 0,
+        (state) => {
+          const s = state as CounterStateType;
+          return s._tag === "Idle" || s._tag === "Ready" ? s.value : 0;
+        },
         () => call3++
       );
 
@@ -490,7 +492,7 @@ describe("TagixContext", () => {
 
       expect(call1).toBe(2); // Initial + dispatch
       expect(call2).toBe(2); // Initial + dispatch
-      expect(call3).toBe(2); // Initial + dispatch (select uses internal notification)
+      expect(call3).toBe(2); // Initial + dispatch (value changes from 0 to 1)
     });
   });
 

--- a/src/store/selectors/test/index.test.ts
+++ b/src/store/selectors/test/index.test.ts
@@ -68,7 +68,7 @@ describe("memoize()", () => {
 
     const obj2 = { value: 5 };
     expect(memoized(obj2)).toBe(10);
-    expect(callCount).toBe(2);
+    expect(callCount).toBe(1);
   });
 
   it("should handle different inputs", () => {


### PR DESCRIPTION
- Added deepMerge() function for recursive object merging
- _mergeAsyncState now uses deep merge instead of shallow merge
- Updated tests to match new deep equality behavior
- Fixes memoize() and Context.select() to use deep equality
- Improves immutability for nested state structures

Ref: #6