### PR TITLE
fix: fork() creates isolated state for contexts

### DIFF
--- a/src/store/context/test/index.test.ts
+++ b/src/store/context/test/index.test.ts
@@ -242,7 +242,7 @@ describe("TagixContext", () => {
 
       fork.dispatch("tagix/action/Increment", { amount: 100 });
 
-      expect(getValue(context.getCurrent())).toBe(110);
+      expect(getValue(context.getCurrent())).toBe(10);
       expect(getValue(fork.getCurrent())).toBe(110);
     });
 
@@ -510,11 +510,9 @@ describe("TagixContext", () => {
 
       store.register("Fail", failingAction);
 
-      expect(() => {
-        context.dispatch("tagix/action/Fail", {});
-      }).toThrow("Test error");
+      context.dispatch("tagix/action/Fail", {});
 
-      expect(store.lastError).toBeInstanceOf(Error);
+      expect(store.lastError instanceof Error).toBe(true);
       expect((store.lastError as Error).message).toBe("Test error");
     });
 
@@ -528,9 +526,11 @@ describe("TagixContext", () => {
       expect(fork1.isDisposed).toBe(false);
       expect(fork2.isDisposed).toBe(false);
 
-      context.dispose();
-
+      fork1.dispose();
       expect(fork1.isDisposed).toBe(true);
+      expect(fork2.isDisposed).toBe(false);
+
+      fork2.dispose();
       expect(fork2.isDisposed).toBe(true);
     });
 


### PR DESCRIPTION
Previously, fork() shared the same store reference with parent, causing state changes in forks to affect the parent. Now fork() creates a completely isolated store with its own state, actions, and error history.

Changes:
- fork() now creates a new TagixStore with copied state and actions
- Removed forkedContexts tracking (forks are independent)
- DerivedContext.fork() delegates to parent context's fork
- merge() uses setState() to update parent's store
- Error handling catches errors instead of throwing for error history
- Updated tests to verify isolated behavior

Ref: #20